### PR TITLE
firstSteps.xml: Fixed parse error in the "View your cases" step.

### DIFF
--- a/com.foglyn.help/firstSteps.xml
+++ b/com.foglyn.help/firstSteps.xml
@@ -49,7 +49,11 @@ When you are done, select <b>Finish</b> button.
 <br/><br/>   
 To create a query, go to <b>Task Repositories</b> view again, and select your new FogBugz repository you created in previous step. From context menu choose <b>New Query...</b> item.
 <br/><br/>
-In this dialog you can choose to create query from preexisting options (My Cases, My Cases for Project, My Cases for Milestone), query based on filter or using advanced search options. Select <b>My Cases</b> for now and click <b>Finish</b> button.newWizardId=org.eclipse.mylyn.tasks.ui.wizards.new.query)" confirm="true" />
+In this dialog you can choose to create query from preexisting options (My Cases, My Cases for Project, My Cases for Milestone), query based on filter or using advanced search options. Select <b>My Cases</b> for now and click <b>Finish</b> button.
+    </description>
+	  <command 
+		  required="false"
+		  serialization="org.eclipse.ui.newWizard(newWizardId=org.eclipse.mylyn.tasks.ui.wizards.new.query)"/>
   </item>
 
   <item title="View your cases">


### PR DESCRIPTION
When I tried installing the foglyn plugin, I got this message on eclipse relaunch:

"Error loading cheat sheet content."
"Cheat sheet content file '/firstSteps.xml' could not be parsed, error at line '53', column '5'."

Looking at firstSteps.xml, it looks like the file had an accidental deletion, and a line or two went missing.  I re-added the missing line and verified that the first steps tutorial parses correctly and is usable.  I am using Eclipse 3.7.
